### PR TITLE
2: get_stock_ohlcv 함수에서 adj 파라미터 오류 수정

### DIFF
--- a/kospi_kosdaq_stock_server.py
+++ b/kospi_kosdaq_stock_server.py
@@ -180,12 +180,12 @@ def get_stock_ohlcv(fromdate: Union[str, int], todate: Union[str, int], ticker: 
         )
         result = dict(sorted_items)
 
-        return json.dumps(result)
+        return result
 
     except Exception as e:
         error_message = f"Data retrieval failed: {str(e)}"
         logging.error(error_message)
-        return json.dumps({"error": error_message})
+        return {"error": error_message}
 
 @mcp.resource("stock://format-guide")
 def get_format_guide() -> str:
@@ -286,12 +286,12 @@ def get_stock_market_cap(fromdate: Union[str, int], todate: Union[str, int], tic
         )
         result = dict(sorted_items)
 
-        return json.dumps(result)
+        return result
 
     except Exception as e:
         error_message = f"Data retrieval failed: {str(e)}"
         logging.error(error_message)
-        return json.dumps({"error": error_message})
+        return {"error": error_message}
 
 @mcp.tool()
 def get_stock_fundamental(fromdate: Union[str, int], todate: Union[str, int], ticker: Union[str, int]) -> Dict[str, Any]:
@@ -351,12 +351,12 @@ def get_stock_fundamental(fromdate: Union[str, int], todate: Union[str, int], ti
         )
         result = dict(sorted_items)
 
-        return json.dumps(result)
+        return result
 
     except Exception as e:
         error_message = f"Data retrieval failed: {str(e)}"
         logging.error(error_message)
-        return json.dumps({"error": error_message})
+        return {"error": error_message}
 
 @mcp.tool()
 def get_stock_trading_volume(fromdate: Union[str, int], todate: Union[str, int], ticker: Union[str, int]) -> Dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kospi-kosdaq-stock-server"
-version = "0.1.22"
+version = "0.1.23"
 description = "KOSPI/KOSDAQ Stock Data MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## 🐛 Bug Fix

### 문제점
아래 메소드들의 정의된 리턴타입과 실제 리턴타입이 다름.
get_stock_market_cap
get_stock_fundamental
get_stock_ohlcv

# 함수 시그니처
def get_stock_market_cap(...) -> Dict[str, Any]:  # 딕셔너리를 반환한다고 선언
    
# 실제 반환값
return json.dumps(result)  # 문자열(JSON)을 반환


### 해결책
- 리턴타입을 dict로 변경

### 변경된 파일
- `kospi_kosdaq_stock_server.py`

### 테스트 결과
- pypi에 신규 버전 0.1.23 배포
- 로컬에서 uv cache clean kospi-kosdaq-stock-server 명령어로 캐시 초기화
- claude desktop 재실행 후 tool 테스트 완료

Fixes #2