### PR TITLE
fix: KRXBlockedError 를 삼키지 않는다 (v0.4.2)

### DIFF
--- a/krx_data_client.py
+++ b/krx_data_client.py
@@ -897,6 +897,11 @@ class KRXAuthManager:
 
         except KRX2FARequiredError:
             raise
+        except (KRXBlockedError, KRX2FARequiredError):
+            # 재시도해도 소용없는 실패는 그대로 올려보낸다. 아래 except 가
+            # 이것들을 일반 KRXAuthError 로 감싸면 재시도 루프가 판별하지 못하고
+            # 제한 중에도 다시 두드리게 된다 — 실서버에서 그렇게 재현됐다.
+            raise
         except Exception as e:
             logger.error(f"카카오 로그인 실패: {e}")
             raise KRXAuthError(f"카카오 로그인 실패: {e}")
@@ -1118,6 +1123,11 @@ class KRXAuthManager:
             logger.info("KRX 직접 로그인 성공")
             return True
 
+        except (KRXBlockedError, KRX2FARequiredError):
+            # 재시도해도 소용없는 실패는 그대로 올려보낸다. 아래 except 가
+            # 이것들을 일반 KRXAuthError 로 감싸면 재시도 루프가 판별하지 못하고
+            # 제한 중에도 다시 두드리게 된다 — 실서버에서 그렇게 재현됐다.
+            raise
         except Exception as e:
             logger.error(f"KRX 직접 로그인 실패: {e}")
             raise KRXAuthError(f"KRX 직접 로그인 실패: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kospi-kosdaq-stock-server"
-version = "0.4.1"
+version = "0.4.2"
 description = "KOSPI/KOSDAQ Stock Data MCP Server with KRX Data Marketplace integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
0.4.1 후속. 실서버에서만 드러난 결함을 고칩니다.

## 증상

0.4.1 을 제한된 호스트에 올려 돌려보니 재시도가 그대로 한 번 더 일어났습니다.

```
ERROR KRX 직접 로그인 실패: KRX가 이 IP의 접근을 제한했습니다 ...
INFO  28.0초 후 재시도... (base=20s, jitter=8.0s)
RESULT: KRXAuthError in 116.7s
```

## 원인

`_login_async_krx` / `_login_async_kakao` 끝의 `except Exception` 이
`KRXBlockedError` 까지 잡아 일반 `KRXAuthError` 로 감쌌습니다. 재시도 루프는
`KRXBlockedError` 를 보고 멈추게 만들었는데, **그 타입이 루프에 도달하기 전에
지워졌습니다.** 그래서 0.4.1 의 서킷 브레이커는 두 번째 호출부터만 효과가
있었습니다.

## 수정

두 함수 모두에서 재시도가 무의미한 예외를 먼저 그대로 올려보냅니다.

```python
except (KRXBlockedError, KRX2FARequiredError):
    raise
except Exception as e:
    ...
```

## 실서버 재검증 (제한 상태)

```
1회차  KRXBlockedError  44.3초   재시도 없음 (116.7초 → 62% 단축)
2회차  쿨다운으로 즉시 차단  0.00초  KRX 를 건드리지 않음
```

유닛 테스트 15/15 는 0.4.1 에서도 통과했습니다. **실제 제한된 호스트에서 돌려야
드러났습니다.**

PyPI 0.4.2 배포 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)